### PR TITLE
Modifying log contents in src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -181,7 +181,7 @@ public class ZookeeperLeaderFinder {
         vertx.createNetClient(netClientOptions)
             .connect(port, host, ar -> {
                 if (ar.failed()) {
-                    LOGGER.warnCr(reconciliation, "ZK {}:{}: failed to connect to zookeeper:", host, port, ar.cause().getMessage());
+                    LOGGER.warnCr(reconciliation, "ZK {}:{}: failed to connect to zookeeper. Attempted to connect to host: {} port: {}. Error: {} Cause: {}", host, port, host, port, ar.cause().getMessage());
                     promise.fail(ar.cause());
                 } else {
                     LOGGER.debugCr(reconciliation, "ZK {}:{}: connected", host, port);


### PR DESCRIPTION
The log message does not conform to standards. It is missing important information such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.

Created by Patchwork Technologies.