### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -411,7 +411,7 @@ public class StrimziPodSetController implements Runnable {
                     metrics.failedReconciliationsCounter(reconciliation.namespace()).increment();
                 } finally {
                     maybeUpdateStatus(reconciliation, podSet, status);
-                    LOGGER.infoCr(reconciliation, "reconciled");
+                    LOGGER.infoCr(reconciliation, "PodSet {0} in namespace {1} reconciled", name, namespace);
                 }
             }
         } finally   {


### PR DESCRIPTION
The log message does not conform to standards. It is missing important information such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message 'reconciled' is concise but not informative enough. It would be more informative if it included details about what was reconciled, such as 'PodSet reconciled'. Additionally, the log message does not include any parameters, which could provide more context about the reconciliation process.

Created by Patchwork Technologies.