### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/nodepools/NodePoolUtils.java
@@ -267,7 +267,7 @@ public class NodePoolUtils {
             String removeNodeIds = Annotations.stringAnnotation(pool, Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, null);
             if (removeNodeIds != null
                     && !NodeIdRange.isValidNodeIdRange(removeNodeIds))    {
-                LOGGER.warnCr(reconciliation, "Invalid annotation {} on KafkaNodePool {} with value {}", Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, pool.getMetadata().getName(), nextNodeIds);
+                                LOGGER.warnCr(reconciliation, 'Invalid annotation {} on KafkaNodePool {} with value {}', Annotations.ANNO_STRIMZI_IO_REMOVE_NODE_IDS, pool.getMetadata().getName(), removeNodeIds);
             }
         });
     }


### PR DESCRIPTION
The log message does not conform to standards. It is missing important information such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message 'reconciled' is concise but not informative enough. It would be more informative if it included details about what was reconciled, such as 'PodSet reconciled'. Additionally, the log message does not include any parameters, which could provide more context about the reconciliation process.
The log message does not conform to the standard as it is missing important information about what was attempted, the error, and the cause. It only includes a generic message without specific details.
The log message is concise and informative, providing details about the invalid annotation and the associated KafkaNodePool. However, there is a mistake in the last parameter where 'nextNodeIds' should be 'removeNodeIds' to match the context of the log message.

Created by Patchwork Technologies.