### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -280,7 +280,7 @@ public abstract class AbstractOperator<
                 S status = (S) e.getStatus();
                 StatusUtils.addConditionsToStatus(status, unknownAndDeprecatedConditions);
 
-                LOGGER.errorCr(reconciliation, "createOrUpdate failed", e.getCause());
+                                LOGGER.errorCr(reconciliation, "Failed to create or update resource {} in namespace {}. Operation failed", name, namespace, e.getCause());
                 updateStatus(reconciliation, status).onComplete(statusResult -> createOrUpdate.fail(e.getCause()));
             } else {
                 LOGGER.errorCr(reconciliation, "createOrUpdate failed", res.cause());


### PR DESCRIPTION
The log message does not conform to standards. It is missing important information such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message 'reconciled' is concise but not informative enough. It would be more informative if it included details about what was reconciled, such as 'PodSet reconciled'. Additionally, the log message does not include any parameters, which could provide more context about the reconciliation process.
The log message does not conform to the standard as it is missing important information about what was attempted, the error, and the cause. It only includes a generic message without specific details.
The log message is concise and informative, providing details about the invalid annotation and the associated KafkaNodePool. However, there is a mistake in the last parameter where 'nextNodeIds' should be 'removeNodeIds' to match the context of the log message.
The log message does not conform to the standard as it is missing important context and details about the warning. It should include more information such as what was attempted, the error, and the cause.
The log message 'createOrUpdate failed' is not very informative as it does not provide details on what was attempted, the error, and the cause of the failure. Including more specific information such as the resource being reconciled and the namespace would make the log message more informative.

Created by Patchwork Technologies.