### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -160,13 +160,7 @@ public class KafkaPool extends AbstractModel {
             StorageDiff diff = new StorageDiff(reconciliation, oldStorage, newStorage, idAssignment.current(), idAssignment.desired());
 
             if (diff.issuesDetected()) {
-                LOGGER.warnCr(reconciliation, "Only the following changes to Kafka storage are allowed: " +
-                        "changing the deleteClaim flag, " +
-                        "changing the kraftMetadata flag (but only one one volume can be marked to store the KRaft metadata log at a time), " +
-                        "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
-                        "each volume in Jbod storage should have an unique ID, " +
-                        "changing overrides to nodes which do not exist yet, " +
-                        "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
+                                LOGGER.warnCr(reconciliation, "Allowed changes to Kafka storage are limited. Review configuration for permitted changes.");
                 LOGGER.warnCr(reconciliation, "The desired Kafka storage configuration in the KafkaNodePool resource {}/{} contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.", pool.getMetadata().getNamespace(), pool.getMetadata().getName());


### PR DESCRIPTION
The log message does not conform to standards. It is missing important information such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message 'reconciled' is concise but not informative enough. It would be more informative if it included details about what was reconciled, such as 'PodSet reconciled'. Additionally, the log message does not include any parameters, which could provide more context about the reconciliation process.
The log message does not conform to the standard as it is missing important information about what was attempted, the error, and the cause. It only includes a generic message without specific details.
The log message is concise and informative, providing details about the invalid annotation and the associated KafkaNodePool. However, there is a mistake in the last parameter where 'nextNodeIds' should be 'removeNodeIds' to match the context of the log message.
The log message does not conform to the standard as it is missing important context and details about the warning. It should include more information such as what was attempted, the error, and the cause.
The log message 'createOrUpdate failed' is not very informative as it does not provide details on what was attempted, the error, and the cause of the failure. Including more specific information such as the resource being reconciled and the namespace would make the log message more informative.
The log message 'createOrUpdate failed' is concise but not informative enough. It should try to include what was attempted, the error, and the cause. In this context, it would be beneficial to include more details about the specific resource that failed to create or update.
The log message is not concise and informative. It does not clearly state what was attempted, the error, and the cause. It also does not provide enough context about the failure. The message should be more specific and provide more details about the failure.
The log message does not conform to the standard as it is not concise and informative. It does not provide details about what was attempted, the error, or the cause of the warning.
The log message does not conform to the standard as it lacks specific information about what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message does not conform to the standard as it is not concise and informative. It does not provide details about what was attempted, the error, or the cause of the warning.
The log message is too long and contains a list of allowed changes to Kafka storage, which makes it difficult to read and understand. It should be concise and informative, focusing on the main point of the warning message.

Created by Patchwork Technologies.