### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
@@ -107,7 +107,7 @@ public final class VertxUtil {
                             try {
                                 result = completed.getAsBoolean();
                             } catch (Throwable e) {
-                                LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
+                                                                LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}. Error: {}", logContext, logState, e.getMessage());
                                 throw e;
                             }
 


### PR DESCRIPTION
The log message does not conform to standards. It is missing important information such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message 'reconciled' is concise but not informative enough. It would be more informative if it included details about what was reconciled, such as 'PodSet reconciled'. Additionally, the log message does not include any parameters, which could provide more context about the reconciliation process.
The log message does not conform to the standard as it is missing important information about what was attempted, the error, and the cause. It only includes a generic message without specific details.
The log message is concise and informative, providing details about the invalid annotation and the associated KafkaNodePool. However, there is a mistake in the last parameter where 'nextNodeIds' should be 'removeNodeIds' to match the context of the log message.
The log message does not conform to the standard as it is missing important context and details about the warning. It should include more information such as what was attempted, the error, and the cause.
The log message 'createOrUpdate failed' is not very informative as it does not provide details on what was attempted, the error, and the cause of the failure. Including more specific information such as the resource being reconciled and the namespace would make the log message more informative.
The log message 'createOrUpdate failed' is concise but not informative enough. It should try to include what was attempted, the error, and the cause. In this context, it would be beneficial to include more details about the specific resource that failed to create or update.
The log message is not concise and informative. It does not clearly state what was attempted, the error, and the cause. It also does not provide enough context about the failure. The message should be more specific and provide more details about the failure.
The log message does not conform to the standard as it is not concise and informative. It does not provide details about what was attempted, the error, or the cause of the warning.
The log message does not conform to the standard as it lacks specific information about what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log message does not conform to the standard as it is not concise and informative. It does not provide details about what was attempted, the error, or the cause of the warning.
The log message is too long and contains a list of allowed changes to Kafka storage, which makes it difficult to read and understand. It should be concise and informative, focusing on the main point of the warning message.
The log message includes parameters for the deployment name and reason, which provides context and makes the log message informative. However, the log level 'infoCr' is not a standard log level and should be reviewed for consistency with the logging framework being used.
The log message does not conform to the standard as it does not provide enough information about what was attempted, the error, and the cause. It only logs the reconciliation and the exception, which is not informative enough.
The log message includes parameters such as 'kind', 'namespace', and 'selector', which provide context about the resource being watched and the reason for the failure. However, the inclusion of the exception 'e' directly in the log message is not recommended as it may expose sensitive information or stack traces. It is better to log the exception separately or handle it appropriately. Additionally, the log message could be more concise by focusing on the main message and moving the exception details to a separate log statement.
The log line does not conform to the standard because it is missing important parameters such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.

Created by Patchwork Technologies.