### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -280,10 +280,10 @@ public abstract class AbstractOperator<
                 S status = (S) e.getStatus();
                 StatusUtils.addConditionsToStatus(status, unknownAndDeprecatedConditions);
 
-                LOGGER.errorCr(reconciliation, "createOrUpdate failed", e.getCause());
+                                LOGGER.errorCr(reconciliation, "Failed to create or update resource {} in namespace {}. Operation failed", name, namespace, e.getCause());
                 updateStatus(reconciliation, status).onComplete(statusResult -> createOrUpdate.fail(e.getCause()));
             } else {
-                LOGGER.errorCr(reconciliation, "createOrUpdate failed", res.cause());
+                LOGGER.errorCr(reconciliation, "Failed to create or update {} {}", e.getMessage());
                 createOrUpdate.fail(res.cause());
             }
         });
@@ -511,7 +511,7 @@ public abstract class AbstractOperator<
                 reconcile(reconciliation);
             }
             case ERROR -> {
-                LOGGER.errorCr(new Reconciliation("watch", this.kind(), namespace, name), "Failed {} {} in namespace{} ", this.kind(), name, namespace);
+                LOGGER.errorCr(new Reconciliation("watch", this.kind(), namespace, name), "Failed {} action on resource {} in namespace {}", action, this.kind(), name, namespace);
                 reconcileAll("watch error", namespace, ignored -> {
                 });
             }


### PR DESCRIPTION
The log message 'createOrUpdate failed' is not very informative as it does not provide details on what was attempted, the error, and the cause of the failure. Including more specific information such as the resource being reconciled and the namespace would make the log message more informative.
The log message 'createOrUpdate failed' is concise but not informative enough. It should try to include what was attempted, the error, and the cause. In this context, it would be beneficial to include more details about the specific resource that failed to create or update.
The log message is not concise and informative. It does not clearly state what was attempted, the error, and the cause. It also does not provide enough context about the failure. The message should be more specific and provide more details about the failure.

Created by Patchwork Technologies.