### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaMirrorMaker2AssemblyOperator.java
@@ -103,7 +103,7 @@ public class KafkaMirrorMaker2AssemblyOperator extends AbstractConnectOperator<K
         try {
             mirrorMaker2Cluster = KafkaMirrorMaker2Cluster.fromCrd(reconciliation, kafkaMirrorMaker2, versions, sharedEnvironmentProvider);
         } catch (Exception e) {
-            LOGGER.warnCr(reconciliation, e);
+                        LOGGER.warnCr(reconciliation, "Failed to update Kafka MirrorMaker 2 cluster", e);
             StatusUtils.setStatusConditionAndObservedGeneration(kafkaMirrorMaker2, kafkaMirrorMaker2Status, e);
             return Future.failedFuture(new ReconciliationException(kafkaMirrorMaker2Status, e));
         }


### PR DESCRIPTION
The log message does not conform to the standard as it is not concise and informative. It does not provide details about what was attempted, the error, or the cause of the warning.

Created by Patchwork Technologies.