### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -160,13 +160,7 @@ public class KafkaPool extends AbstractModel {
             StorageDiff diff = new StorageDiff(reconciliation, oldStorage, newStorage, idAssignment.current(), idAssignment.desired());
 
             if (diff.issuesDetected()) {
-                LOGGER.warnCr(reconciliation, "Only the following changes to Kafka storage are allowed: " +
-                        "changing the deleteClaim flag, " +
-                        "changing the kraftMetadata flag (but only one one volume can be marked to store the KRaft metadata log at a time), " +
-                        "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
-                        "each volume in Jbod storage should have an unique ID, " +
-                        "changing overrides to nodes which do not exist yet, " +
-                        "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
+                                LOGGER.warnCr(reconciliation, "Allowed changes to Kafka storage are limited. Review configuration for permitted changes.");
                 LOGGER.warnCr(reconciliation, "The desired Kafka storage configuration in the KafkaNodePool resource {}/{} contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.", pool.getMetadata().getNamespace(), pool.getMetadata().getName());


### PR DESCRIPTION
The log message is too long and contains a list of allowed changes to Kafka storage, which makes it difficult to read and understand. It should be concise and informative, focusing on the main point of the warning message.

Created by Patchwork Technologies.