### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java
@@ -56,7 +56,7 @@ public class ReconnectingWatcher<T extends HasMetadata> implements Watcher<T> {
 
     @Override
     public void onClose(WatcherException e) {
-        LOGGER.warnOp("Watch for resource {} in namespace {} with selector {} failed and will be reconnected", kind, namespace, selector,  e);
+                LOGGER.warnOp("Watch for resource {} in namespace {} with selector {} failed and will be reconnected. Exception: {}", kind, namespace, selector, e.getMessage());
         watch = createWatch(); // We recreate the watch
     }
 


### PR DESCRIPTION
The log message includes parameters such as 'kind', 'namespace', and 'selector', which provide context about the resource being watched and the reason for the failure. However, the inclusion of the exception 'e' directly in the log message is not recommended as it may expose sensitive information or stack traces. It is better to log the exception separately or handle it appropriately. Additionally, the log message could be more concise by focusing on the main message and moving the exception details to a separate log statement.

Created by Patchwork Technologies.