### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
@@ -107,7 +107,7 @@ public final class VertxUtil {
                             try {
                                 result = completed.getAsBoolean();
                             } catch (Throwable e) {
-                                LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
+                                                                LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}. Error: {}", logContext, logState, e.getMessage());
                                 throw e;
                             }
 
@@ -129,7 +129,7 @@ public final class VertxUtil {
                                     long timeLeft = deadline - System.currentTimeMillis();
                                     if (timeLeft <= 0) {
                                         String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
-                                        LOGGER.errorCr(reconciliation, exceptionMessage);
+                                        LOGGER.errorCr(reconciliation, "Exceeded timeout of {0}ms while waiting for {1} to be {2}", timeoutMs, logContext, logState);
                                         promise.fail(new TimeoutException(exceptionMessage));
                                     } else {
                                         // Schedule ourselves to run again


### PR DESCRIPTION
The log line does not conform to the standard because it is missing important parameters such as what was attempted, the error, and the cause. Including these details would make the log message more informative and helpful for debugging purposes.
The log line does not conform to the standards because it does not provide enough information about the error. It should include what was attempted, the error, and the cause. In this case, the log message should provide more context about the specific reconciliation, logContext, and logState that caused the error.

Created by Patchwork Technologies.