### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -775,7 +775,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         }
                     }
                 } else {
-                    LOGGER.errorCr(reconciliation, "Current {} resource not found", resource.getKind());
+                                        LOGGER.errorCr(reconciliation, "Current {} resource of type {} not found for resource named {}", resource.getKind(), resource.getClass().getSimpleName(), resource.getMetadata().getName());
                     updateStatusPromise.fail("Current " + resource.getKind() + " resource not found");
                 }
             } else {


### PR DESCRIPTION
The log message does not conform to the standards because it lacks specific details about the attempted action, the error, and the cause. It only mentions 'Current {} resource not found' without specifying the resource type or any additional context.

Created by Patchwork Technologies.