### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingUtils.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingUtils.java
@@ -184,7 +184,7 @@ public class LoggingUtils {
                     try {
                         is.close();
                     } catch (IOException e) {
-                        LOGGER.errorCr(reconciliation, "Failed to close stream. Reason: " + e.getMessage());
+                                                LOGGER.errorCr(reconciliation, "Failed to close stream after reading default log config file from '" + logConfigFile + "'. Root cause: " + e.getMessage());
                     }
                 }
             }


### PR DESCRIPTION
The log message includes the reason for the failure, which is good. However, it lacks information about what was attempted and the root cause of the error. Including more context about what operation was being performed when the stream failed and the root cause of the failure would make the log message more informative.

Created by Patchwork Technologies.