### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZooKeeperRoller.java
@@ -156,7 +156,7 @@ public class ZooKeeperRoller {
      * @return a Future which completes when the given (possibly recreated) pod is ready.
      */
     Future<Void> restartPod(Reconciliation reconciliation, String podName, List<String> reasons) {
-        LOGGER.infoCr(reconciliation, "Rolling Pod {} due to {}", podName, reasons);
+        LOGGER.info(reconciliation, "Rolling Pod {} due to {}", podName, reasons);
         return podOperator.getAsync(reconciliation.namespace(), podName)
                 .compose(pod -> podOperator.restart(reconciliation, pod, operationTimeoutMs))
                 .compose(ignore -> {


### PR DESCRIPTION
- The log message includes parameters such as 'podName' and 'reasons', which provide context about the action being taken. However, the log level 'infoCr' is not a standard log level. It is recommended to use standard log levels like 'info' or 'error' for better clarity and consistency.


Created by Patchwork Technologies.