### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperLeaderFinder.java
@@ -181,7 +181,7 @@ public class ZookeeperLeaderFinder {
         vertx.createNetClient(netClientOptions)
             .connect(port, host, ar -> {
                 if (ar.failed()) {
-                    LOGGER.warnCr(reconciliation, "ZK {}:{}: failed to connect to zookeeper:", host, port, ar.cause().getMessage());
+                    LOGGER.warnCr(reconciliation, "Failed to connect to Zookeeper at {}:{} - Reason: {}", host, port, ar.cause().getMessage());
                     promise.fail(ar.cause());
                 } else {
                     LOGGER.debugCr(reconciliation, "ZK {}:{}: connected", host, port);


### PR DESCRIPTION
- The log message is not concise and informative. It should provide more context about the specific failure that occurred when trying to connect to Zookeeper. Additionally, the log message does not follow the standard of including parameters related to the error, such as the host and port values. The message should be more specific and include relevant details to aid in troubleshooting.


Created by Patchwork Technologies.