### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/StrimziPodSetController.java
@@ -406,12 +406,12 @@ public class StrimziPodSetController implements Runnable {
                     status.setCurrentPods(podCounter.currentPods);
                     metrics.successfulReconciliationsCounter(reconciliation.namespace()).increment();
                 } catch (Exception e) {
-                    LOGGER.errorCr(reconciliation, "StrimziPodSet {} in namespace {} reconciliation failed", reconciliation.name(), reconciliation.namespace(), e);
+                    LOGGER.errorCr(reconciliation, "StrimziPodSet {} reconciliation failed", reconciliation.name(), e);
                     status.addCondition(StatusUtils.buildConditionFromException("Error", "true", e));
                     metrics.failedReconciliationsCounter(reconciliation.namespace()).increment();
                 } finally {
                     maybeUpdateStatus(reconciliation, podSet, status);
-                    LOGGER.infoCr(reconciliation, "reconciled");
+                    LOGGER.infoCr(reconciliation, "PodSet reconciled for resource name: {} in namespace: {}", name, namespace);
                 }
             }
         } finally   {
@@ -445,7 +445,7 @@ public class StrimziPodSetController implements Runnable {
                 } else if (e.getCode() == 404) {
                     LOGGER.debugCr(reconciliation, "StrimziPodSet {} in namespace {} was deleted while trying to update status", reconciliation.name(), reconciliation.namespace());
                 } else {
-                    LOGGER.errorCr(reconciliation, "Failed to update status of StrimziPodSet {} in namespace {}", reconciliation.name(), reconciliation.namespace(), e);
+                    LOGGER.errorCr(reconciliation, "Failed to update status of StrimziPodSet {} in namespace {}. Error: {}", reconciliation.name(), reconciliation.namespace(), e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
- The log message includes the attempted action (reconciliation), the error (reconciliation failed), and the cause (exception 'e'). It also includes the necessary parameters such as the name and namespace of the StrimziPodSet. However, the log message is quite long and could be more concise by removing the unnecessary details such as 'in namespace'. Including only 'StrimziPodSet {} reconciliation failed' would still provide the necessary information without being overly verbose.
- The log message 'reconciled' is concise but not informative enough. It would be more informative if it included details about what was reconciled, such as 'PodSet reconciled'. Additionally, the log message does not include any parameters related to the reconciliation process, such as the name or namespace of the resource being reconciled. Including these parameters would make the log message more informative.
- The log line does not conform to the standard because it does not provide a clear indication of what was attempted, the error, and the cause of the error. The log message 'Failed to update status of StrimziPodSet {} in namespace {}' is too generic and does not provide specific details about the attempted action, the error that occurred, and the cause of the error.


Created by Patchwork Technologies.