### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/kubernetes/ConfigMapOperator.java
@@ -56,7 +56,7 @@ public class ConfigMapOperator extends AbstractNamespacedResourceOperator<Kubern
                 return super.internalUpdate(reconciliation, namespace, name, current, desired);
             }
         } catch (Exception e) {
-            LOGGER.errorCr(reconciliation, "Caught exception while patching {} {} in namespace {}", resourceKind, name, namespace, e);
+            LOGGER.errorCr(reconciliation, "Error patching {} {} in namespace {}: {}", resourceKind, name, namespace, e.getMessage());
             return Future.failedFuture(e);
         }
     }


### PR DESCRIPTION
- The log message includes the parameters 'resourceKind', 'name', 'namespace', and 'e' which provide information about what was attempted, the error, and the cause. However, the log message is not concise as it includes 'Caught exception while patching' which is redundant given the context of the method. It would be better to have a more concise message that focuses on the specific error or exception being caught.


Created by Patchwork Technologies.