### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/ZookeeperScaler.java
@@ -154,7 +154,7 @@ public class ZookeeperScaler implements AutoCloseable {
                 .onSuccess(nothing -> connected.complete(zkAdmin))
                 .onFailure(cause -> {
                     String message = String.format("Failed to connect to Zookeeper %s. Connection was not ready in %d ms.", zookeeperConnectionString, operationTimeoutMs);
-                    LOGGER.warnCr(reconciliation, message);
+                    LOGGER.warnCr(reconciliation, "Failed to connect to Zookeeper {}. Connection was not ready in {} ms.", zookeeperConnectionString, operationTimeoutMs);
 
                     closeConnection(zkAdmin)
                         .onComplete(nothing -> connected.fail(new ZookeeperScalingException(message, cause)));


### PR DESCRIPTION
- The log message does not conform to standards because it is missing important information such as what was attempted, the error, and the cause. The log message should provide more context about the specific failure that occurred during the connection attempt to Zookeeper.


Created by Patchwork Technologies.