### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KRaftMigrationUtils.java
@@ -88,7 +88,7 @@ public class KRaftMigrationUtils {
                     .onSuccess(v -> connected.complete(zkAdmin))
                     .onFailure(cause -> {
                         String message = String.format("Failed to connect to ZooKeeper %s. Connection was not ready in %d ms.", zkConnectionString, operationTimeoutMs);
-                        LOGGER.warnCr(reconciliation, message);
+                        LOGGER.warnCr(reconciliation, "Failed to connect to Zookeeper {}. Error: {}", zkConnectionString, e);
 
                         closeZooKeeperConnection(reconciliation, vertx, zkAdmin, trustStoreFile, keyStoreFile, operationTimeoutMs)
                                 .onComplete(nothing -> connected.fail(new RuntimeException(message, cause)));


### PR DESCRIPTION
- The log message does not conform to standards because it is missing the cause of the warning. It should include what was attempted, the error, and the cause. In this case, the log message should provide more context about why the connection to Zookeeper failed.


Created by Patchwork Technologies.