### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerConfigurationDiff.java
@@ -239,7 +239,7 @@ public class KafkaBrokerConfigurationDiff extends AbstractJsonDiff {
             // if the entry was custom, it should be deleted
             if (!isIgnorableProperty(pathValueWithoutSlash, nodeIsController)) {
                 updatedCE.add(new AlterConfigOp(new ConfigEntry(pathValueWithoutSlash, null), AlterConfigOp.OpType.DELETE));
-                LOGGER.infoCr(reconciliation, "{} not set in desired, unsetting back to default {}", entry.name(), "deleted entry");
+                LOGGER.infoCr(reconciliation, 
             } else {
                 LOGGER.traceCr(reconciliation, "{} is ignorable, not considering as removed");
             }


### PR DESCRIPTION
- The log message includes parameters such as entry.name() and a hardcoded string 'deleted entry', which provides context about what was attempted and the result. However, the log message is not concise and informative as it includes unnecessary details like 'unsetting back to default'. This information is not relevant to understanding the log message and could be misleading. It would be better to provide a more concise and informative message.


Created by Patchwork Technologies.