### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractOperator.java
@@ -280,10 +280,10 @@ public abstract class AbstractOperator<
                 S status = (S) e.getStatus();
                 StatusUtils.addConditionsToStatus(status, unknownAndDeprecatedConditions);
 
-                LOGGER.errorCr(reconciliation, "createOrUpdate failed", e.getCause());
+                LOGGER.errorCr(reconciliation, "Failed to perform createOrUpdate operation", e.getCause());
                 updateStatus(reconciliation, status).onComplete(statusResult -> createOrUpdate.fail(e.getCause()));
             } else {
-                LOGGER.errorCr(reconciliation, "createOrUpdate failed", res.cause());
+                LOGGER.errorCr(reconciliation, "Failed to create or update resource", e.getCause());
                 createOrUpdate.fail(res.cause());
             }
         });
@@ -355,7 +355,7 @@ public abstract class AbstractOperator<
                             return Future.succeededFuture();
                         }
                     } else {
-                        LOGGER.errorCr(reconciliation, "Current {} resource not found", reconciliation.kind());
+                        LOGGER.errorCr(reconciliation, "Current {} resource not found. Attempted to get {} resource with name {}", reconciliation.kind(), reconciliation.kind(), name);
                         return Future.failedFuture("Current " + reconciliation.kind() + " resource with name " + name + " not found");
                     }
                 }, error -> {
@@ -429,7 +429,7 @@ public abstract class AbstractOperator<
         try {
             return callable.call();
         } catch (Throwable ex) {
-            LOGGER.errorCr(reconciliation, "Reconciliation failed", ex);
+            LOGGER.errorCr("Attempted reconciliation: " + reconciliation.getName() + ". Error: " + ex.getMessage(), ex);
             return Future.failedFuture(ex);
         }
     }


### PR DESCRIPTION
- The log message does not conform to the standards as it is missing important information such as what was attempted and the cause of the error. It only mentions 'createOrUpdate failed' without providing any context or details.
- The log message does not conform to the standard as it is missing information about what was attempted and the cause of the error. It only mentions 'createOrUpdate failed' without providing additional context.
- The log message does not conform to the standards because it is missing the cause of the error. It should include what was attempted, the error, and the cause. In this case, the log message should provide more context about why the current resource was not found.
- The log message does not conform to standards. It should include what was attempted, the error, and the cause for an exception log message. In this case, the log message should provide more context about the reconciliation that failed and the specific error that occurred.
- The log message includes parameters such as 'name' and 'namespace' which provide context about the action being performed. However, the log message is not concise and informative as it is too verbose and redundant. The log message could be simplified to provide the necessary information without repeating the same details multiple times.


Created by Patchwork Technologies.