### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -160,13 +160,12 @@ public class KafkaPool extends AbstractModel {
             StorageDiff diff = new StorageDiff(reconciliation, oldStorage, newStorage, idAssignment.current(), idAssignment.desired());
 
             if (diff.issuesDetected()) {
-                LOGGER.warnCr(reconciliation, "Only the following changes to Kafka storage are allowed: " +
-                        "changing the deleteClaim flag, " +
-                        "changing the kraftMetadata flag (but only one one volume can be marked to store the KRaft metadata log at a time), " +
-                        "adding volumes to Jbod storage or removing volumes from Jbod storage, " +
-                        "each volume in Jbod storage should have an unique ID, " +
-                        "changing overrides to nodes which do not exist yet, " +
-                        "and increasing size of persistent claim volumes (depending on the volume type and used storage class).");
+                LOGGER.warnCr(reconciliation, "Only the following changes to Kafka storage are allowed: changing the deleteClaim flag");
+LOGGER.warnCr(reconciliation, "changing the kraftMetadata flag (but only one volume can be marked to store the KRaft metadata log at a time)");
+LOGGER.warnCr(reconciliation, "adding volumes to Jbod storage or removing volumes from Jbod storage");
+LOGGER.warnCr(reconciliation, "each volume in Jbod storage should have an unique ID");
+LOGGER.warnCr(reconciliation, "changing overrides to nodes which do not exist yet");
+LOGGER.warnCr(reconciliation, "increasing size of persistent claim volumes (depending on the volume type and used storage class)");
                 LOGGER.warnCr(reconciliation, "The desired Kafka storage configuration in the KafkaNodePool resource {}/{} contains changes which are not allowed. As a " +
                         "result, all storage changes will be ignored. Use DEBUG level logging for more information " +
                         "about the detected changes.", pool.getMetadata().getNamespace(), pool.getMetadata().getName());


### PR DESCRIPTION
- The log message is too long and contains a list of allowed changes to Kafka storage, which makes it hard to read and understand. It would be more concise and informative to split the message into multiple log lines, each focusing on a specific allowed change.


Created by Patchwork Technologies.