### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaBrokerLoggingConfigurationDiff.java
@@ -134,7 +134,7 @@ public class KafkaBrokerLoggingConfigurationDiff extends AbstractJsonDiff {
                 }
             }
         } catch (Exception e) {
-            LOGGER.errorCr(reconciliation, "Failed to parse logging configuration: " + config, e);
+            LOGGER.errorCr(reconciliation, "Failed to parse logging configuration for reconciliation: " + config + ", error: " + e.getMessage(), e);
             return Collections.emptyMap();
         }
 


### PR DESCRIPTION
- The log message does not conform to the standards. It should include what was attempted, the error, and the cause for the exception. In this case, the log message only mentions 'Failed to parse logging configuration' without specifying what exactly was attempted and the root cause of the failure.


Created by Patchwork Technologies.