### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/CaReconciler.java
@@ -589,7 +589,7 @@ public class CaReconciler {
         return deploymentOperator.getAsync(reconciliation.namespace(), deploymentName)
                 .compose(dep -> {
                     if (dep != null) {
-                        LOGGER.infoCr(reconciliation, "Rolling Deployment {} due to {}", deploymentName, reason);
+                        LOGGER.infoCr(operationName, "Rolling Deployment {} due to {}", deploymentName, reason);
                         return deploymentOperator.rollingUpdate(reconciliation, reconciliation.namespace(), deploymentName, operationTimeoutMs);
                     } else {
                         return Future.succeededFuture();


### PR DESCRIPTION
- The log message includes parameters such as 'deploymentName' and 'reason', which provide context about the action being taken. However, the parameter 'reconciliation' is not descriptive enough and does not provide clear information about what was attempted. It would be better to include a more descriptive parameter or message to provide more context.


Created by Patchwork Technologies.