### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ReconnectingWatcher.java
@@ -56,7 +56,7 @@ public class ReconnectingWatcher<T extends HasMetadata> implements Watcher<T> {
 
     @Override
     public void onClose(WatcherException e) {
-        LOGGER.warnOp("Watch for resource {} in namespace {} with selector {} failed and will be reconnected", kind, namespace, selector,  e);
+        LOGGER.warnOp("Failed to watch resource {} in namespace {} with selector {}. Will attempt to reconnect. Exception details: {}", kind, namespace, selector, e.getMessage());
         watch = createWatch(); // We recreate the watch
     }
 


### PR DESCRIPTION
- The log message includes too many parameters which can make it hard to read and understand. It violates the standard of being concise and informative. Additionally, the log message seems to be for an exception, but it lacks details about what was attempted, the error, and the cause. The exception 'e' should be handled more appropriately in the log message.


Created by Patchwork Technologies.