### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/VertxUtil.java
@@ -107,7 +107,7 @@ public final class VertxUtil {
                             try {
                                 result = completed.getAsBoolean();
                             } catch (Throwable e) {
-                                LOGGER.warnCr(reconciliation, "Caught exception while waiting for {} to get {}", logContext, logState, e);
+                                LOGGER.warnCr(reconciliation, "Exception encountered while waiting for {} to get {}: {}", logContext, logState, e.getMessage());
                                 throw e;
                             }
 
@@ -129,7 +129,7 @@ public final class VertxUtil {
                                     long timeLeft = deadline - System.currentTimeMillis();
                                     if (timeLeft <= 0) {
                                         String exceptionMessage = String.format("Exceeded timeout of %dms while waiting for %s to be %s", timeoutMs, logContext, logState);
-                                        LOGGER.errorCr(reconciliation, exceptionMessage);
+                                        LOGGER.errorCr(reconciliation, "Exceeded timeout of {0}ms while waiting for {1} to be {2}", timeoutMs, logContext, logState);
                                         promise.fail(new TimeoutException(exceptionMessage));
                                     } else {
                                         // Schedule ourselves to run again


### PR DESCRIPTION
- The log message includes parameters such as logContext, logState, and the exception 'e', which provides context about what was being waited for and the cause of the exception. However, the log message is not concise as it includes unnecessary information such as 'Caught exception while waiting for'. It would be more informative if the log message focused on the specific exception or error encountered.
- The log message does not conform to standards. It is missing the specific details of the error, what was attempted, and the cause of the error. Including these details would make the log message more informative and helpful for debugging purposes.


Created by Patchwork Technologies.