### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/ConnectBuildOperator.java
@@ -392,7 +392,7 @@ public class ConnectBuildOperator {
                     } else {
                         // Build failed. If the Status exists, we try to provide more detailed information
                         if (build.getStatus() != null) {
-                            LOGGER.infoCr(reconciliation, "Build {} failed with code {}: {}", buildName, build.getStatus().getPhase(), build.getStatus().getLogSnippet());
+                            LOGGER.infoCr(failureReason, "Build {} failed with code {}: {}", buildName, build.getStatus().getPhase(), build.getStatus().getLogSnippet());
                         } else {
                             LOGGER.warnCr(reconciliation, "Build {} failed for unknown reason", buildName);
                         }


### PR DESCRIPTION
- The log message includes parameters such as buildName, build.getStatus().getPhase(), and build.getStatus().getLogSnippet(), which provide relevant information about the build failure. However, the 'reconciliation' parameter is not descriptive enough and should be replaced with a more informative message or variable name.


Created by Patchwork Technologies.