### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/resource/KafkaRoller.java
@@ -507,7 +507,7 @@ public class KafkaRoller {
                     restartContext.restartReasons.add(RestartReason.POD_FORCE_RESTART_ON_ERROR);
                     restartAndAwaitReadiness(pod, operationTimeoutMs, TimeUnit.MILLISECONDS, restartContext);
                 } else {
-                    LOGGER.warnCr(reconciliation, "Pod {} can't be safely force-rolled; original error: ", nodeRef, e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+                    LOGGER.warnCr(reconciliation, "Pod {} can't be safely force-rolled; original error: {}", nodeRef, e.getCause() != null ? e.getCause().getMessage() : e.getMessage())
                     throw e;
                 }
             } else {
@@ -740,7 +740,7 @@ public class KafkaRoller {
         KafkaFuture<Void> brokerLoggingConfigFuture = alterConfigResult.values().get(Util.getBrokersLogging(podId));
         await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerConfigFuture), 30, TimeUnit.SECONDS,
             error -> {
-                LOGGER.errorCr(reconciliation, "Error updating broker configuration for pod {}", nodeRef, error);
+                LOGGER.errorCr(reconciliation, "Error updating broker configuration for pod {} due to: {}", nodeRef, error.getMessage());
                 return new ForceableProblem("Error updating broker configuration for pod " + nodeRef, error);
             });
         await(VertxUtil.kafkaFutureToVertxFuture(reconciliation, vertx, brokerLoggingConfigFuture), 30, TimeUnit.SECONDS,


### PR DESCRIPTION
- The log message is not concise and informative. It should provide more context about the specific error that occurred and why the pod can't be safely force-rolled. Additionally, the log message is missing the original error message which would provide more information about the root cause of the issue.
- The log message does not conform to the standard as it is missing the cause of the error. It should include what was attempted, the error, and the cause. In this case, the log message should provide more context about the specific error that occurred while updating the broker configuration for the pod.


Created by Patchwork Technologies.