### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/AbstractConnectOperator.java
@@ -765,7 +765,7 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                                     LOGGER.debugCr(reconciliation, "Completed status update");
                                     updateStatusPromise.complete();
                                 } else {
-                                    LOGGER.errorCr(reconciliation, "Failed to update status", updateRes.cause());
+                                    LOGGER.errorCr(reconciliation, "Failed to update status of resource {} due to: {}", fetchedResource.getMetadata().getName(), updateRes.cause());
                                     updateStatusPromise.fail(updateRes.cause());
                                 }
                             });
@@ -775,11 +775,11 @@ public abstract class AbstractConnectOperator<C extends KubernetesClient, T exte
                         }
                     }
                 } else {
-                    LOGGER.errorCr(reconciliation, "Current {} resource not found", resource.getKind());
+                    LOGGER.errorCr(reconciliation, "Current {} resource not found. Attempted to retrieve resource of kind: {}", resource.getKind(), getRes.cause());
                     updateStatusPromise.fail("Current " + resource.getKind() + " resource not found");
                 }
             } else {
-                LOGGER.errorCr(reconciliation, "Failed to get the current {} resource and its status", resource.getKind(), getRes.cause());
+                LOGGER.errorCr(reconciliation, "Failed to get the current {} resource and its status. Error: {}", resource.getKind(), getRes.cause().getMessage());
                 updateStatusPromise.fail(getRes.cause());
             }
         });


### PR DESCRIPTION
- The log message does not conform to the standards because it lacks specific details about the attempted action, the error, and the cause. It only mentions 'Failed to update status' without providing more context on what status update failed and why.
- The log message does not conform to the standards because it is missing the cause of the error. It should include what was attempted, the error, and the cause for better context.
- The log message includes parameters such as 'resource.getKind()' and 'getRes.cause()', providing context about the resource and the cause of the failure. However, the log message is not concise and informative. It could be improved by specifying what was attempted, the error, and the cause in a more structured manner.


Created by Patchwork Technologies.