### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaReconciler.java
@@ -903,7 +903,7 @@ public class KafkaReconciler {
                         String bootstrapHostname = KafkaResources.bootstrapServiceName(reconciliation.name()) + "." + reconciliation.namespace() + ".svc:" + KafkaCluster.REPLICATION_PORT;
                         LOGGER.debugCr(reconciliation, "Creating AdminClient for clusterId using {}", bootstrapHostname);
                         kafkaAdmin = adminClientProvider.createAdminClient(bootstrapHostname, this.coTlsPemIdentity.pemTrustSet(), this.coTlsPemIdentity.pemAuthIdentity());
-                        kafkaStatus.setClusterId(kafkaAdmin.describeCluster().clusterId().get());
+                        LOGGER.debugCr(reconciliation, "Attempt to get clusterId and handle exceptions");
                     } catch (KafkaException e) {
                         LOGGER.warnCr(reconciliation, "Kafka exception getting clusterId {}", e.getMessage());
                     } catch (InterruptedException e) {


### PR DESCRIPTION
- The log line does not conform to the standard as it is missing important context and information. It should include what was attempted, the error (if any), and the cause. In this case, the log message should provide more context about the attempt to get the cluster ID and handle any exceptions that may occur during this operation.


Created by Patchwork Technologies.