### PR TITLE
Modifying log contents in cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingUtils.java

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/logging/LoggingUtils.java
@@ -184,7 +184,7 @@ public class LoggingUtils {
                     try {
                         is.close();
                     } catch (IOException e) {
-                        LOGGER.errorCr(reconciliation, "Failed to close stream. Reason: " + e.getMessage());
+                        LOGGER.errorCr(reconciliation, "Failed to close input stream for log config file: " + logConfigFile + ". Reason: " + e.getMessage());
                     }
                 }
             }


### PR DESCRIPTION
- The log message 'Failed to close stream. Reason: ' does not provide enough context about what was attempted, the error, and the cause. It would be more informative if the log message included what stream was being closed and why it failed.


Created by Patchwork Technologies.